### PR TITLE
test: created copy of pr-verification

### DIFF
--- a/.github/workflows/pr-verification-copy.yml
+++ b/.github/workflows/pr-verification-copy.yml
@@ -1,0 +1,16 @@
+name: Pull Request Verification Copy
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  Check-Team-Membership:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.HACKFORLA_ADMIN_TOKEN }}
+          script: |
+            const verifyPR = require('./github-actions/trigger-pr-target/verify-pr.js');
+            verifyPR({github, context});

--- a/github-actions/utils/check-team-membership.js
+++ b/github-actions/utils/check-team-membership.js
@@ -13,6 +13,8 @@ docs on printing context information into the log.
 
 async function isMemberOfTeam(github, githubUsername, team) {
     try {
+        console.log('team', team)
+        console.log("githubUsername", githubUsername);
         await github.rest.teams.getMembershipForUserInOrg({
             org: 'hackforla',
             team_slug: team,
@@ -22,6 +24,7 @@ async function isMemberOfTeam(github, githubUsername, team) {
         console.log(`User '${githubUsername}' is member of team '${team}'`);
         return true;
     } catch (verificationError) {
+        console.log('verificationError', verificationError)
         if (verificationError.status == 404) {
             console.log(`User '${githubUsername}' is not a team member`);
             return false;


### PR DESCRIPTION
Please note: You must be a member of the HFLA website team in order to create pull requests. Please see our page on how to join us as a member at HFLA: https://www.hackforla.org/getting-started. Delete this message if you joined this team via onboarding.
<!--  Note: Delete the message above if you joined this team via onboarding  -->

<!--  Important! Add the number of the issue you worked on  --> 
Fixes #replace_this_text_with_the_issue_number

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - 
  - 
  - 

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - 
  - 
  - 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [ ] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
